### PR TITLE
Add Binance DCA bot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-NO CONTENT
+# Binance DCA Bot
+
+This repository contains a basic example of a Dollar Cost Averaging (DCA) bot for long-term Bitcoin investment on Binance.
+
+## Requirements
+
+- Python 3.8+
+- The `requests` package is not required; the script uses built-in modules.
+- Binance API key and secret.
+
+## Usage
+
+1. Set the environment variables `BINANCE_API_KEY` and `BINANCE_API_SECRET` with your Binance API credentials.
+2. Run the bot:
+
+```bash
+python3 binance_dca_bot.py
+```
+
+By default the script will invest 100 USDT in BTC every week for 10 weeks. Edit `binance_dca_bot.py` if you want to change the amount, interval, or number of iterations.
+
+## Disclaimer
+
+This code is provided for educational purposes only. Investing in cryptocurrencies involves risk. Use at your own discretion.

--- a/binance_dca_bot.py
+++ b/binance_dca_bot.py
@@ -1,0 +1,58 @@
+import hmac
+import hashlib
+import time
+import urllib.parse
+import urllib.request
+import json
+import os
+
+BASE_URL = "https://api.binance.com"
+
+
+def _sign_params(params, api_secret):
+    query_string = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+    signature = hmac.new(api_secret.encode("utf-8"), query_string.encode("utf-8"), hashlib.sha256).hexdigest()
+    return query_string + f"&signature={signature}"
+
+
+def _send_signed_request(http_method: str, url_path: str, payload: dict, api_key: str, api_secret: str):
+    payload["timestamp"] = int(time.time() * 1000)
+    query = _sign_params(payload, api_secret)
+    url = f"{BASE_URL}{url_path}?{query}"
+    req = urllib.request.Request(url, method=http_method)
+    req.add_header("X-MBX-APIKEY", api_key)
+    with urllib.request.urlopen(req) as resp:
+        data = resp.read()
+        return json.loads(data)
+
+
+def buy_bitcoin_usdt(amount_usdt: float, api_key: str, api_secret: str):
+    payload = {
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "type": "MARKET",
+        "quoteOrderQty": amount_usdt,
+    }
+    return _send_signed_request("POST", "/api/v3/order", payload, api_key, api_secret)
+
+
+def dollar_cost_average(amount_usdt: float, interval_sec: int, iterations: int, api_key: str, api_secret: str):
+    for i in range(iterations):
+        print(f"Purchase {i + 1} / {iterations}")
+        try:
+            response = buy_bitcoin_usdt(amount_usdt, api_key, api_secret)
+            print("Order response:", response)
+        except Exception as e:
+            print("Error placing order:", e)
+        if i < iterations - 1:
+            time.sleep(interval_sec)
+
+
+if __name__ == "__main__":
+    API_KEY = os.getenv("BINANCE_API_KEY")
+    API_SECRET = os.getenv("BINANCE_API_SECRET")
+    if not API_KEY or not API_SECRET:
+        raise SystemExit("Please set BINANCE_API_KEY and BINANCE_API_SECRET environment variables")
+
+    # Example: invest 100 USDT every week for 10 weeks
+    dollar_cost_average(amount_usdt=100, interval_sec=7 * 24 * 60 * 60, iterations=10, api_key=API_KEY, api_secret=API_SECRET)


### PR DESCRIPTION
## Summary
- implement `binance_dca_bot.py` showing a simple DCA approach for BTC on Binance
- document usage in `README.md`

## Testing
- `python3 binance_dca_bot.py` *(fails: missing credentials)*
- `python3 -m py_compile binance_dca_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68530a30f5cc832c927cf519399ff4ba