### PR TITLE
Add .env support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-NO CONTENT
+# Binance DCA Bot
+
+This repository contains a basic example of a Dollar Cost Averaging (DCA) bot for long-term Bitcoin investment on Binance.
+
+## Requirements
+
+- Python 3.8+
+- The `requests` package is not required; the script uses built-in modules.
+- Binance API key and secret stored in a `.env` file.
+
+## Usage
+
+1. Create a `.env` file containing your credentials:
+
+```
+BINANCE_API_KEY=your_key
+BINANCE_API_SECRET=your_secret
+TELEGRAM_TOKEN=your_bot_token       # optional
+TELEGRAM_CHAT_ID=your_chat_id       # optional
+```
+
+2. Run the bot:
+
+```bash
+python3 binance_dca_bot.py
+```
+
+By default the script will invest 100 USDT in BTC every week for 10 weeks. Edit `binance_dca_bot.py` if you want to change the amount, interval, or number of iterations.
+
+When Telegram integration is enabled you can control the bot with the following commands:
+
+- `pause` – suspend purchases
+- `reprendre` – resume purchases
+- `status` – display current balance
+- `log X` – show the last X days of log entries
+- `help` – list the commands
+
+## Disclaimer
+
+This code is provided for educational purposes only. Investing in cryptocurrencies involves risk. Use at your own discretion.

--- a/binance_dca_bot.py
+++ b/binance_dca_bot.py
@@ -1,0 +1,150 @@
+import hmac
+import hashlib
+import time
+import urllib.parse
+import urllib.request
+import json
+import os
+from datetime import datetime
+
+
+def load_env(path: str = ".env") -> None:
+    """Load key=value pairs from a .env file into os.environ."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                os.environ.setdefault(key.strip(), value.strip())
+    except FileNotFoundError:
+        pass
+
+from telegram_bot import TelegramBot
+
+BASE_URL = "https://api.binance.com"
+
+
+def _sign_params(params, api_secret):
+    query_string = urllib.parse.urlencode(params, quote_via=urllib.parse.quote)
+    signature = hmac.new(api_secret.encode("utf-8"), query_string.encode("utf-8"), hashlib.sha256).hexdigest()
+    return query_string + f"&signature={signature}"
+
+
+def _send_signed_request(http_method: str, url_path: str, payload: dict, api_key: str, api_secret: str):
+    payload["timestamp"] = int(time.time() * 1000)
+    query = _sign_params(payload, api_secret)
+    url = f"{BASE_URL}{url_path}?{query}"
+    req = urllib.request.Request(url, method=http_method)
+    req.add_header("X-MBX-APIKEY", api_key)
+    with urllib.request.urlopen(req) as resp:
+        data = resp.read()
+        return json.loads(data)
+
+
+def buy_bitcoin_usdt(amount_usdt: float, api_key: str, api_secret: str):
+    payload = {
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "type": "MARKET",
+        "quoteOrderQty": amount_usdt,
+    }
+    return _send_signed_request("POST", "/api/v3/order", payload, api_key, api_secret)
+
+
+def get_account_summary(api_key: str, api_secret: str) -> str:
+    data = _send_signed_request("GET", "/api/v3/account", {}, api_key, api_secret)
+    balances = {b["asset"]: float(b["free"]) + float(b["locked"]) for b in data.get("balances", [])}
+    btc = balances.get("BTC", 0.0)
+    usdt = balances.get("USDT", 0.0)
+    return f"BTC: {btc} | USDT: {usdt}"
+
+
+PAUSED = False
+
+
+def dollar_cost_average(amount_usdt: float, interval_sec: int, iterations: int, api_key: str, api_secret: str, telegram: TelegramBot | None = None):
+    next_time = time.time()
+    for i in range(iterations):
+        while True:
+            if not PAUSED and time.time() >= next_time:
+                break
+            time.sleep(1)
+        if telegram:
+            telegram.send_message(f"Achat {i + 1}/{iterations} de {amount_usdt} USDT de BTC")
+            telegram.log(f"buy {amount_usdt} USDT")
+        try:
+            response = buy_bitcoin_usdt(amount_usdt, api_key, api_secret)
+            print("Order response:", response)
+        except Exception as e:
+            print("Error placing order:", e)
+            if telegram:
+                telegram.send_message(f"Erreur lors de l'achat: {e}")
+        next_time += interval_sec
+
+
+def handle_command(text: str, api_key: str, api_secret: str, telegram: TelegramBot):
+    global PAUSED
+    cmd = text.strip().lower()
+    if cmd == "pause":
+        PAUSED = True
+        telegram.send_message("Programme en pause")
+        telegram.log("pause")
+    elif cmd in ("reprendre", "resume"):
+        if PAUSED:
+            PAUSED = False
+            telegram.send_message("Programme repris")
+            telegram.log("resume")
+    elif cmd == "status":
+        telegram.send_message(get_account_summary(api_key, api_secret))
+    elif cmd.startswith("log"):
+        parts = cmd.split()
+        days = 1
+        if len(parts) > 1 and parts[1].isdigit():
+            days = int(parts[1])
+        telegram.send_message(telegram.recent_logs(days))
+    elif cmd in ("aide", "help"):
+        telegram.send_message(
+            "Commandes:\n"
+            "pause - met le programme en pause\n"
+            "reprendre - relance le programme\n"
+            "status - affiche le statut\n"
+            "log X - log des X derniers jours\n"
+            "help - cette aide"
+        )
+
+
+if __name__ == "__main__":
+    # Load environment variables from .env if available
+    load_env()
+    API_KEY = os.getenv("BINANCE_API_KEY")
+    API_SECRET = os.getenv("BINANCE_API_SECRET")
+    if not API_KEY or not API_SECRET:
+        raise SystemExit("Please set BINANCE_API_KEY and BINANCE_API_SECRET environment variables")
+
+    TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+    TELEGRAM_CHAT = os.getenv("TELEGRAM_CHAT_ID")
+    telegram = None
+    if TELEGRAM_TOKEN and TELEGRAM_CHAT:
+        telegram = TelegramBot(TELEGRAM_TOKEN, TELEGRAM_CHAT)
+        telegram.log("start")
+        telegram.send_message(f"Bot lancé. {get_account_summary(API_KEY, API_SECRET)}")
+        telegram.start_polling(lambda text: handle_command(text, API_KEY, API_SECRET, telegram))
+
+    try:
+        # Example: invest 100 USDT every week for 10 weeks
+        dollar_cost_average(
+            amount_usdt=100,
+            interval_sec=7 * 24 * 60 * 60,
+            iterations=10,
+            api_key=API_KEY,
+            api_secret=API_SECRET,
+            telegram=telegram,
+        )
+    finally:
+        if telegram:
+            telegram.send_message(f"Bot arrêté. {get_account_summary(API_KEY, API_SECRET)}")
+            telegram.log("stop")
+            telegram.stop_polling()
+

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,76 @@
+import urllib.parse
+import urllib.request
+import json
+import time
+import threading
+from datetime import datetime, timedelta
+
+
+class TelegramBot:
+    def __init__(self, token: str, chat_id: str, log_file: str = "bot.log"):
+        self.token = token
+        self.chat_id = chat_id
+        self.api_url = f"https://api.telegram.org/bot{token}"
+        self.log_file = log_file
+        self.offset = None
+        self._polling_thread = None
+        self._stop_event = threading.Event()
+
+    def log(self, message: str):
+        timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        with open(self.log_file, "a", encoding="utf-8") as f:
+            f.write(f"{timestamp} - {message}\n")
+
+    def send_message(self, text: str):
+        data = urllib.parse.urlencode({"chat_id": self.chat_id, "text": text}).encode()
+        req = urllib.request.Request(f"{self.api_url}/sendMessage", data=data)
+        with urllib.request.urlopen(req) as resp:
+            resp.read()
+        self.log(f"sent: {text}")
+
+    def get_updates(self):
+        params = {"timeout": 100}
+        if self.offset:
+            params["offset"] = self.offset
+        url = f"{self.api_url}/getUpdates?{urllib.parse.urlencode(params)}"
+        with urllib.request.urlopen(url) as resp:
+            data = json.load(resp)
+        if data.get("ok"):
+            for update in data.get("result", []):
+                self.offset = update["update_id"] + 1
+                message = update.get("message")
+                if message and "text" in message:
+                    yield message["text"]
+
+    def start_polling(self, handler):
+        def _poll():
+            while not self._stop_event.is_set():
+                try:
+                    for text in self.get_updates() or []:
+                        handler(text)
+                except Exception:
+                    time.sleep(1)
+        self._polling_thread = threading.Thread(target=_poll, daemon=True)
+        self._polling_thread.start()
+
+    def stop_polling(self):
+        self._stop_event.set()
+        if self._polling_thread:
+            self._polling_thread.join(timeout=1)
+
+    def recent_logs(self, days: int) -> str:
+        cutoff = datetime.utcnow() - timedelta(days=days)
+        lines = []
+        try:
+            with open(self.log_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        ts_str, rest = line.split(" - ", 1)
+                        ts = datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S")
+                        if ts >= cutoff:
+                            lines.append(line.strip())
+                    except ValueError:
+                        continue
+        except FileNotFoundError:
+            return "No logs found."
+        return "\n".join(lines) if lines else "No recent logs." 


### PR DESCRIPTION
## Summary
- allow loading Binance and Telegram credentials from a `.env` file
- document `.env` usage and environment variables in README
- rename Telegram token variable to `TELEGRAM_TOKEN`

## Testing
- `python3 -m py_compile binance_dca_bot.py telegram_bot.py`
- `python3 binance_dca_bot.py` *(fails: missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68530a30f5cc832c927cf519399ff4ba